### PR TITLE
Update the download link to 16.04.2

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -21,8 +21,8 @@
             </div>
             <div class="four-col last-col no-margin-bottom">
                 <p>选择版本</p>
-                <p><a href="http://releases.ubuntu.com/16.04/ubuntu-16.04-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">64位下载键</a>
-                <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
+                <p><a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+                <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
                 <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
             </div>
         </div>


### PR DESCRIPTION
## Done
Updated the download links to the desktop LTS to the new point release.

## QA
- Run `make clean-all run`
- Go to http://127.0.0.1:8010/download/
- Check that the two links work unlike on live

## Issue / Card
Fixes https://github.com/canonical-websites/cn.ubuntu.com/issues/121
Fixes https://github.com/canonical-websites/cn.ubuntu.com/pull/122
