### PR TITLE
Fix navigation styling on medium screens

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -372,6 +372,9 @@ footer.global {
     padding-top: 20px;
   }
 
+  header.banner .nav-primary ul li a:hover {
+    background-color: #E1662F;
+  }
 
 } // end @media only screen and (min-width : 768px)
 
@@ -403,10 +406,6 @@ footer.global {
   header.banner .nav-primary ul li a.active {
     background: #B83A10;
     border-left: 1px solid lighten($ubuntu_orange, 7%);
-  }
-
-  header.banner .nav-primary ul li a:hover {
-    background-color: #E1662F;
   }
 
   #nav-global .nav-global-wrapper {


### PR DESCRIPTION
## Done
Moved the hover background styling to a medium breakpoint from large only.

## QA
- Pull branch
- Run `make clean-all run`
- Go to http://localhost:8010/ on medium screen
- Hover over the nav and see that it light orange not grey

## Issue / Card
Fixes https://github.com/canonical-websites/cn.ubuntu.com/issues/55
