### PR TITLE
Add margins to all download sections

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -6,95 +6,103 @@
 {% block meta_keywords %}{{ meta_keywords }}{% endblock %}
 
 {% block second_level_nav_items %}
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Download"  %}
+{% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Download"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
 <div class="row row-grey">
-    <div class="eight-col append-four">
-        {% include "templates/_cms-block.html" with block_content=hero %}
+  <div class="eight-col append-four">
+    {% include "templates/_cms-block.html" with block_content=hero %}
+  </div>
+  <div class="twelve-col box box-highlight clearfix vertical-divider">
+    <div class="eight-col no-margin-bottom">
+      {% include "templates/_cms-block.html" with block_content=lts_ubuntu_release extra_classes="lts-ubuntu-content" %}
     </div>
-    <div class="twelve-col box box-highlight clearfix vertical-divider">
-        <div class="eight-col no-margin-bottom">
-            {% include "templates/_cms-block.html" with block_content=lts_ubuntu_release extra_classes="lts-ubuntu-content" %}
-        </div>
-        <div class="four-col last-col no-margin-bottom">
-            <p>选择版本</p>
-            <p><a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 64 bit', 'From English-language Chinese download']);">64位下载键</a>
-            <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
-            <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-        </div>
+    <div class="four-col last-col no-margin-bottom">
+      <p>选择版本</p>
+      <p>
+        <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+        <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 32 bit', 'From English-language Chinese download']);">32位下载键</a>
+      </p>
+      <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
     </div>
-    <div class="twelve-col box box-highlight clearfix vertical-divider">
-        <div class="eight-col no-margin-bottom">
-            {% include "templates/_cms-block.html" with block_content=lts_kylin_release extra_classes="lts-kylin-content" %}
-        </div>
-        <div class="four-col last-col no-margin-bottom download-button">
-            <p>选择版本</p>
-            <p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
-            <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
-            <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-        </div>
+  </div>
+  <div class="twelve-col box box-highlight clearfix vertical-divider">
+    <div class="eight-col no-margin-bottom">
+      {% include "templates/_cms-block.html" with block_content=lts_kylin_release extra_classes="lts-kylin-content" %}
     </div>
+    <div class="four-col last-col no-margin-bottom download-button">
+      <p>选择版本</p>
+      <p>
+        <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
+        <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a>
+      </p>
+      <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
+    </div>
+  </div>
 </div>
 
 <div class="row row-grey">
-	<div class="twelve-col box box-highlight clearfix vertical-divider">
-		<div class="eight-col no-margin-bottom">
-			{% include "templates/_cms-block.html" with block_content=latest_ubuntu_release extra_classes="latest-ubuntu-content" %}
-		</div>
-		<div class="four-col last-col no-margin-bottom">
-			<p>选择版本</p>
-			<p><a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">64位下载键</a>
-			<a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
-			<p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-		</div>
-	</div>
-	<div class="twelve-col box box-highlight clearfix vertical-divider">
-		<div class="eight-col no-margin-bottom">
-			{% include "templates/_cms-block.html" with block_content=latest_kylin_release extra_classes="latest-kylin-content" %}
-		</div>
-		<div class="four-col last-col no-margin-bottom download-button">
-			<p>选择版本</p>
-			<p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
-			<a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
-			<p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-		</div>
-	</div>
+  <div class="twelve-col box box-highlight clearfix vertical-divider">
+    <div class="eight-col no-margin-bottom">
+      {% include "templates/_cms-block.html" with block_content=latest_ubuntu_release extra_classes="latest-ubuntu-content" %}
+    </div>
+    <div class="four-col last-col no-margin-bottom">
+      <p>选择版本</p>
+      <p>
+        <a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+        <a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">32位下载键</a>
+      </p>
+      <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
+    </div>
+  </div>
+  <div class="twelve-col box box-highlight clearfix vertical-divider">
+    <div class="eight-col no-margin-bottom">
+      {% include "templates/_cms-block.html" with block_content=latest_kylin_release extra_classes="latest-kylin-content" %}
+    </div>
+    <div class="four-col last-col no-margin-bottom download-button">
+      <p>选择版本</p>
+      <p>
+        <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
+        <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a>
+      </p>
+      <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
+    </div>
+  </div>
 </div>
 
 <div class="row">
-    <div class="eight-col">
-        {% include "templates/_cms-block.html" with block_content=other_downloads extra_classes="other-downloads" %}
+  <div class="eight-col">
+    {% include "templates/_cms-block.html" with block_content=other_downloads extra_classes="other-downloads" %}
+  </div>
+  <div class="equal-height">
+    <div class="box six-col">
+      {% include "templates/_cms-block.html" with block_content=alternative_1 extra_classes="alternative-1" %}
     </div>
-    <div class="equal-height">
-        <div class="box six-col">
-            {% include "templates/_cms-block.html" with block_content=alternative_1 extra_classes="alternative-1" %}
-        </div>
-        <div class="box six-col last-col">
-            {% include "templates/_cms-block.html" with block_content=alternative_2 extra_classes="alternative-2" %}
-        </div>
-        <div class="box six-col">
-            {% include "templates/_cms-block.html" with block_content=cloud extra_classes="cloud" %}
-        </div>
-        <div class="box six-col last-col">
-            {% include "templates/_cms-block.html" with block_content=server extra_classes="server" %}
-        </div>
+    <div class="box six-col last-col">
+      {% include "templates/_cms-block.html" with block_content=alternative_2 extra_classes="alternative-2" %}
     </div>
+    <div class="box six-col">
+      {% include "templates/_cms-block.html" with block_content=cloud extra_classes="cloud" %}
+    </div>
+    <div class="box six-col last-col">
+      {% include "templates/_cms-block.html" with block_content=server extra_classes="server" %}
+    </div>
+  </div>
 </div>
 
 <div class="row row-community row-grey no-border">
-    <div class="three-col text-center">
-        <img class="picto" src="{{ STATIC_URL }}img/pictograms/picto-pack/picto-community-orange.svg" alt="" width="150" height="150" />
+  <div class="three-col text-center">
+    <img class="picto" src="{{ STATIC_URL }}img/pictograms/picto-pack/picto-community-orange.svg" alt="" width="150" height="150" />
+  </div>
+  <div class="nine-col last-col">
+    <div class="six-col">
+      {% include "templates/_cms-block.html" with block_content=community  extra_classes="community" %}
     </div>
-    <div class="nine-col last-col">
-        <div class="six-col">
-            {% include "templates/_cms-block.html" with block_content=community  extra_classes="community" %}
-        </div>
-        <div class="three-col last-col box where-to-find-us smaller">
-            {% include "templates/_cms-block.html" with block_content=community_links extra_classes="community-links" %}
-        </div>
+    <div class="three-col last-col box where-to-find-us smaller">
+      {% include "templates/_cms-block.html" with block_content=community_links extra_classes="community-links" %}
     </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -14,61 +14,53 @@
     <div class="eight-col append-four">
         {% include "templates/_cms-block.html" with block_content=hero %}
     </div>
-    <div class="twelve-col">
-        <div class="box box-highlight clearfix vertical-divider">
-            <div class="eight-col no-margin-bottom">
-                {% include "templates/_cms-block.html" with block_content=lts_ubuntu_release extra_classes="lts-ubuntu-content" %}
-            </div>
-            <div class="four-col last-col no-margin-bottom">
-                <p>选择版本</p>
-                <p><a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 64 bit', 'From English-language Chinese download']);">64位下载键</a>
-                <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
-                <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-            </div>
+    <div class="twelve-col box box-highlight clearfix vertical-divider">
+        <div class="eight-col no-margin-bottom">
+            {% include "templates/_cms-block.html" with block_content=lts_ubuntu_release extra_classes="lts-ubuntu-content" %}
+        </div>
+        <div class="four-col last-col no-margin-bottom">
+            <p>选择版本</p>
+            <p><a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+            <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
+            <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
         </div>
     </div>
-    <div class="twelve-col no-margin-bottom">
-        <div class="box box-highlight clearfix vertical-divider">
-            <div class="eight-col no-margin-bottom">
-                {% include "templates/_cms-block.html" with block_content=lts_kylin_release extra_classes="lts-kylin-content" %}
-            </div>
-            <div class="four-col last-col no-margin-bottom download-button">
-                <p>选择版本</p>
-                <p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
-                <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
-                <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-            </div>
+    <div class="twelve-col box box-highlight clearfix vertical-divider">
+        <div class="eight-col no-margin-bottom">
+            {% include "templates/_cms-block.html" with block_content=lts_kylin_release extra_classes="lts-kylin-content" %}
+        </div>
+        <div class="four-col last-col no-margin-bottom download-button">
+            <p>选择版本</p>
+            <p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
+            <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
+            <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
         </div>
     </div>
 </div>
 
 <div class="row row-grey">
-    <div class="twelve-col">
-        <div class="box box-highlight clearfix vertical-divider">
-            <div class="eight-col no-margin-bottom">
-                {% include "templates/_cms-block.html" with block_content=latest_ubuntu_release extra_classes="latest-ubuntu-content" %}
-            </div>
-            <div class="four-col last-col no-margin-bottom">
-                <p>选择版本</p>
-                <p><a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">64位下载键</a>
-                <a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
-                <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-            </div>
-        </div>
-    </div>
-    <div class="twelve-col no-margin-bottom">
-        <div class="box box-highlight clearfix vertical-divider">
-            <div class="eight-col no-margin-bottom">
-                {% include "templates/_cms-block.html" with block_content=latest_kylin_release extra_classes="latest-kylin-content" %}
-            </div>
-            <div class="four-col last-col no-margin-bottom download-button">
-                <p>选择版本</p>
-                <p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
-                <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
-                <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
-            </div>
-        </div>
-    </div>
+	<div class="twelve-col box box-highlight clearfix vertical-divider">
+		<div class="eight-col no-margin-bottom">
+			{% include "templates/_cms-block.html" with block_content=latest_ubuntu_release extra_classes="latest-ubuntu-content" %}
+		</div>
+		<div class="four-col last-col no-margin-bottom">
+			<p>选择版本</p>
+			<p><a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+			<a href="http://releases.ubuntu.com/16.10/ubuntu-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
+			<p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
+		</div>
+	</div>
+	<div class="twelve-col box box-highlight clearfix vertical-divider">
+		<div class="eight-col no-margin-bottom">
+			{% include "templates/_cms-block.html" with block_content=latest_kylin_release extra_classes="latest-kylin-content" %}
+		</div>
+		<div class="four-col last-col no-margin-bottom download-button">
+			<p>选择版本</p>
+			<p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
+			<a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.10/release/ubuntukylin-16.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
+			<p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
+		</div>
+	</div>
 </div>
 
 <div class="row">


### PR DESCRIPTION
## Done
Removed the `no-margin-bottom` to the download sections. Also moved the column styling on to the box so the boxes take up the entire space even if the content is short.

## QA
- Pull branch
- Run `make run`
- Go to http://localhost:8010/download on small screen
- Check the download boxes work better then on live http://cn.ubuntu.com/download/

## Issue / Card
Fixes https://github.com/canonical-websites/cn.ubuntu.com/issues/60

