### PR TITLE
Fix URLs to latest ISO version

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -21,8 +21,8 @@
     <div class="four-col last-col no-margin-bottom">
       <p>选择版本</p>
       <p>
-        <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 64 bit', 'From English-language Chinese download']);">64位下载键</a>
-        <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.2-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.2 32 bit', 'From English-language Chinese download']);">32位下载键</a>
+        <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.3-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.3 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+        <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.3-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.3 32 bit', 'From English-language Chinese download']);">32位下载键</a>
       </p>
       <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
     </div>


### PR DESCRIPTION
## Done

Fixed the URLs on the download page

## QA

- `./run`
- go to [/download/](http://localhost:8010/download/)
- See that the upper two buttons correctly download ISOs (compare to 404s on live)

## Issue / Card
Fixes #144 