### PR TITLE
Change manage.py to stop pointing at python 3

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
Python 3 currently causes problems in our deployment set up while we are migrating services over.
