### PR TITLE
Convert cloud page to Vanilla

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -5,7 +5,7 @@
 {% if meta_description %}{% block meta_description %}{{ meta_description }}{% endblock %}{% endif %}
 
 {% block second_level_nav_items %}
-{% include "templates/_nav_breadcrumb.html" with section_title="云" page_title="云"  %}
+  {% include "templates/_nav_breadcrumb.html" with section_title="云" page_title="云"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
@@ -21,11 +21,11 @@
     </div>
   </div>
 </section>
+
 <section class="p-strip--image is-dark" style="background-image:url('/static/img/backgrounds/background-grid.png');background-repeat: repeat;background-size: auto;">
   <div id="ubuntu-offers" class="row">
     <div class="col-12">
       <h2>Ubuntu 为您提供哪些服务</h2>
-
       <ul class="p-list">
         <li class="p-list is-ticked">方便您有效构建 OpenStack 云所需的一切服务</li>
         <li class="p-list is-ticked">在领先的公共云上使用经认证的Ubuntu 服务器映像</li>
@@ -123,8 +123,8 @@
 <section class="p-strip is-bordered">
   <div id="network-operators" class="row">
     <div class="col-8">
-        <h2>网络运营商首选</h2>
-        <p>如果您是电信运营商或服务提供商，且您想为您的客户提供云服务，那么 Ubuntu OpenStack 就是您最可靠也是最受欢迎的基础设施。我们已经帮助世界上大多数电信运营商和服务提供商巨头实现了 OpenStack 云。</p>
+      <h2>网络运营商首选</h2>
+      <p>如果您是电信运营商或服务提供商，且您想为您的客户提供云服务，那么 Ubuntu OpenStack 就是您最可靠也是最受欢迎的基础设施。我们已经帮助世界上大多数电信运营商和服务提供商巨头实现了 OpenStack 云。</p>
     </div>
   </div>
 </section>
@@ -132,13 +132,15 @@
 <section class="p-strip">
   <div id="services-or-support" class="row">
     <div class="col-6">
-        <h2>需要服务或支持？</h2>
-        <p>Canonical 是 Ubuntu 的技术支持公司，其直接参与开发 Ubuntu 和 OpenStack 的工程师会为用户提供现场咨询服务和培训服务。如果要在您的云启动和运行后获得后继支持服务，您可以订阅 Ubuntu Advantage 服务包（包括 Canonical 企业云管理软件 Landscape）。</p><p></p>
-        <p><a href="http://www.ubuntu.com/management/ubuntu-advantage">请访问 www.ubuntu.com 进一步了解 Ubuntu Advantage</a></p>
+      <h2>需要服务或支持？</h2>
+      <p>Canonical 是 Ubuntu 的技术支持公司，其直接参与开发 Ubuntu 和 OpenStack 的工程师会为用户提供现场咨询服务和培训服务。如果要在您的云启动和运行后获得后继支持服务，您可以订阅 Ubuntu Advantage 服务包（包括 Canonical 企业云管理软件 Landscape）。</p>
+      <p></p>
+      <p><a href="http://www.ubuntu.com/management/ubuntu-advantage">请访问 www.ubuntu.com 进一步了解 Ubuntu Advantage</a></p>
     </div>
     <div class="col-6">
       <img src="{{ STATIC_URL }}img/cloud/image-landscape.jpg" alt="Landscape" />
     </div>
   </div>
 </section>
-  {% endblock %}
+
+{% endblock %}

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -1,95 +1,144 @@
 {% extends "cloud/base_cloud.html" %}
-{% load markdown_deux_tags %}
 
-{% block title %}{{ title }}{% endblock %}
-{% block meta_description %}{{ meta_description }}{% endblock %}
-{% block meta_keywords %}{{ meta_keywords }}{% endblock %}
-{% block extra_body_class %}cloud-home{% endblock %}
+{% if title %}{% block title %}{{ title }}{% endblock %}{% endif %}
+
+{% if meta_description %}{% block meta_description %}{{ meta_description }}{% endblock %}{% endif %}
 
 {% block second_level_nav_items %}
-    {% include "templates/_nav_breadcrumb.html" with section_title="云" page_title="云"  %}
+{% include "templates/_nav_breadcrumb.html" with section_title="云" page_title="云"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-{# ================ 1. Ubuntu for cloud ================ #}
-<div class="row">
-    <div class="seven-col">
-        {% include "templates/_cms-block.html" with block_content=hero %}
-    </div>
-    <div class="five-col last-col text-center">
-        <img src="{{ STATIC_URL }}img/cloud/image-ecosystem.svg" width="250" height="250" alt="" />
-    </div>
-</div>
 
-{# ================ 2. What Ubuntu offers you ================ #}
-<div id="ubuntu-offers" class="row no-border strip-dark">
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <h1>云用 Ubuntu</h1>
+      <p>无论您是构建自己的云，还是想使用 公共云，Ubuntu 为您提供您需要的 所有软件基础设施、工具和服务。</p>
+    </div>
+    <div class="col-5 u-align--center">
+      <img src="{{ STATIC_URL }}img/cloud/image-ecosystem.svg" width="250" height="250" alt="" />
+    </div>
+  </div>
+</section>
+<section class="p-strip--image is-dark" style="background-image:url('/static/img/backgrounds/background-grid.png');background-repeat: repeat;background-size: auto;">
+  <div id="ubuntu-offers" class="row">
     <div class="col-12">
-        {% include "templates/_cms-block.html" with block_content=ubuntu_offers %}
-    </div>
-</div>
+      <h2>Ubuntu 为您提供哪些服务</h2>
 
-{# ================ 3. Build your own cloud with Ubuntu OpenStack ================ #}
-<div id="build-with-openstack" class="row">
-    <div class="col-8">
-        {% include "templates/_cms-block.html" with block_content=openstack %}
+      <ul class="p-list">
+        <li class="p-list is-ticked">方便您有效构建 OpenStack 云所需的一切服务</li>
+        <li class="p-list is-ticked">在领先的公共云上使用经认证的Ubuntu 服务器映像</li>
+        <li class="p-list is-ticked">成熟的工具帮您大规模配置、构建、管理和支持您的云</li>
+        <li class="p-list is-ticked">定制化咨询业务和后继 Ubuntu Advantage 支持订购服务等商业服务</li>
+      </ul>
     </div>
-    <div class="four-col last-col">
-        <blockquote class="pull-quote">
-            <p><span>“</span>Ubuntu 始终是用来部署 OpenStack 的最流行的操作系统&nbsp;<span>”</span></p>
-            <p><cite>OpenStack 用户调查（2013 年 11 月&#65289;</cite></p>
-        </blockquote>
-    </div>
-</div>
+  </div>
+</section>
 
-{# ================ 4. Using Ubuntu in the public cloud ================ #}
-<div id="public-cloud" class="row">
+<section class="p-strip is-bordered">
+  <div id="build-with-openstack" class="row">
     <div class="col-8">
-        {% include "templates/_cms-block.html" with block_content=public_cloud %}
+      <h2>使用 Ubuntu OpenStack 构建自己的云</h2>
+      <p>Ubuntu OpenStack 是 Ubuntu 服务器最新版本和OpenStack 最新版本的组合版。OpenStack 主要发行版本获得 Ubuntu LTS 版五年支持，具有 OpenStack 最新功能，方便用户安心使用。</p>
+      <p>Ubuntu 拥有与云端整合的悠久历史，能比任何其他操作系统都更快速和更简单地进行部署。</p>
+      <p><a href="http://www.ubuntu.com/cloud/ubuntu-openstack">进一步了解 Ubuntu OpenStack</a></p>
     </div>
+    <div class="col-4">
+      <blockquote class="p-pull-quote">
+        <p>Ubuntu 始终是用来部署 OpenStack 的最流行的操作系统</p>
+        <cite class="p-pull-quote__citation">OpenStack 用户调查（2013 年 11 月&#65289;</cite>
+      </blockquote>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div id="public-cloud" class="row">
+    <div class="col-8">
+      <h2>在公共云上使用 Ubuntu</h2>
+      <p>Ubuntu 是领先公共云上最流行的操作系统，也是世界上发展最快的自如扩展平台。以下公共云提供经认证的 Ubuntu服务器映像（由 Canonical 创建）。</p>
+      <p><a href="http://www.ubuntu.com/cloud/use-a-cloud">进一步了解如何在云中使用 Ubuntu</a></p>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-12">
-        <ul class="inline-logos no-bullets no-margin">
-            <li class="first-item"><img src="{{ STATIC_URL }}img/logos/logo-amazonwebservices-160.png" alt="AWS"></li>
-            <li><img src="{{ STATIC_URL }}img/logos/logo-hp-cloud-160.png" alt="HP cloud"></li>
-            <li class="last-item"><img src="{{ STATIC_URL }}img/logos/logo-joyent-160.png" alt="Joyent"></li>
-            <li><img src="{{ STATIC_URL }}img/logos/logo-ibm-160.png" alt="IBM"></li>
-            <li class="last-item"><img src="{{ STATIC_URL }}img/logos/logo-microsoftazure.svg" alt="Azure"></li>
-        </ul>
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
+          <img src="{{ STATIC_URL }}img/logos/logo-amazonwebservices-160.png" alt="AWS">
+        </li>
+        <li class="p-inline-images__item">
+          <img src="{{ STATIC_URL }}img/logos/logo-hp-cloud-160.png" alt="HP cloud">
+        </li>
+        <li class="p-inline-images__item">
+          <img src="{{ STATIC_URL }}img/logos/logo-joyent-160.png" alt="Joyent">
+        </li>
+        <li class="p-inline-images__item">
+          <img src="{{ STATIC_URL }}img/logos/logo-ibm-160.png" alt="IBM">
+        </li>
+        <li class="p-inline-images__item">
+          <img src="{{ STATIC_URL }}img/logos/logo-microsoftazure.svg" alt="Azure">
+        </li>
+      </ul>
     </div>
-</div>
+  </div>
+</section>
 
-{# ================ 5. A complete set of cloud tools ================ #}
-<div id="cloud-tools" class="row row-cloud-tools">
+<section class="p-strip is-bordered">
+  <div id="cloud-tools" class="row">
     <div class="col-8">
-        {% include "templates/_cms-block.html" with block_content=cloud_tools %}
+      <h2>一套完整的云计算工具</h2>
+      <p>Ubuntu 提供的工具方便您长期创建、扩展和管理您的云。</p>
     </div>
-    <div class="twelve-col vertical-divider">
-        <div class="four-col">
-            <p class="u-align--center"><img src="{{ STATIC_URL }}img/cloud/image-maascharts.png" alt="MAAS"></p>
-            {% include "templates/_cms-block.html" with block_content=tools_maas %}
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="p-divider">
+        <div class="col-4 p-divider__block">
+          <p class="u-align--center"><img src="{{ STATIC_URL }}img/cloud/image-maascharts.png" alt="MAAS"></p>
+          <h3><a href="http://www.ubuntu.com/cloud/tools/maas">MAAS</a></h3>
+          <h4>免费软件</h4>
+          <p>MAAS 负责您的服务器的初始安装和配置工作，并将其集成到您的网络中。</p>
+          <p><a href="http://www.ubuntu.com/cloud/tools/maas">进一步了解 MAAS</a></p>
         </div>
-        <div class="four-col">
-            <p class="u-align--center"><img src="{{ STATIC_URL }}img/cloud/image-jujucharms.png" alt="Juju"></p>
-            {% include "templates/_cms-block.html" with block_content=tools_juju %}
+        <div class="col-4 p-divider__block">
+          <p class="u-align--center"><img src="{{ STATIC_URL }}img/cloud/image-jujucharms.png" alt="Juju"></p>
+          <h3><a href="http://www.ubuntu.com/cloud/tools/juju">Juju</a></h3>
+          <h4>免费软件</h4>
+          <p>Juju 是服务编排的一场革命。能在几秒钟内在运行 Ubuntu 的任一云上部署服务（如 MySQL 和 Hadoop）</p>
+          <p><a href="http://www.ubuntu.com/cloud/tools/juju">进一步了解 Juju</a></p>
         </div>
-        <div class="four-col last-col">
-            <p class="u-align--center"><img src="{{ STATIC_URL }}img/cloud/image-autopilot.jpg" alt="Autopilot"></p>
-            {% include "templates/_cms-block.html" with block_content=tools_autopilot %}
+        <div class="col-4 p-divider__block">
+          <p class="u-align--center"><img src="{{ STATIC_URL }}img/cloud/image-autopilot.jpg" alt="Autopilot"></p>
+          <h3><a href="http://www.ubuntu.com/management/working-with-landscape">Autopilot</a></h3>
+          <h4>前10台机器免费</h4>
+          <p>Autopilot是开发，部署及扩展OpenStack云的强大新方式。</p>
+          <p><a href="http://www.ubuntu.com/cloud/openstack/autopliot">了解更多相关Autopilot的内容</a></p>
         </div>
+      </div>
     </div>
-</div>
+  </div>
+</section>
 
-{# ================ 6. Number one for network operators ================ #}
-<div id="network-operators" class="row">
+<section class="p-strip is-bordered">
+  <div id="network-operators" class="row">
     <div class="col-8">
-        {% include "templates/_cms-block.html" with block_content=network_operators %}
+        <h2>网络运营商首选</h2>
+        <p>如果您是电信运营商或服务提供商，且您想为您的客户提供云服务，那么 Ubuntu OpenStack 就是您最可靠也是最受欢迎的基础设施。我们已经帮助世界上大多数电信运营商和服务提供商巨头实现了 OpenStack 云。</p>
     </div>
-</div>
+  </div>
+</section>
 
-{# ================ 7. Need services or support? ================ #}
-<div id="services-or-support" class="row row-services no-border">
-    <div class="six-col">
-        {% include "templates/_cms-block.html" with block_content=support %}
+<section class="p-strip">
+  <div id="services-or-support" class="row">
+    <div class="col-6">
+        <h2>需要服务或支持？</h2>
+        <p>Canonical 是 Ubuntu 的技术支持公司，其直接参与开发 Ubuntu 和 OpenStack 的工程师会为用户提供现场咨询服务和培训服务。如果要在您的云启动和运行后获得后继支持服务，您可以订阅 Ubuntu Advantage 服务包（包括 Canonical 企业云管理软件 Landscape）。</p><p></p>
+        <p><a href="http://www.ubuntu.com/management/ubuntu-advantage">请访问 www.ubuntu.com 进一步了解 Ubuntu Advantage</a></p>
     </div>
-    <img src="{{ STATIC_URL }}img/cloud/image-landscape.jpg" alt="Landscape" />
-</div>
-{% endblock %}
+    <div class="col-6">
+      <img src="{{ STATIC_URL }}img/cloud/image-landscape.jpg" alt="Landscape" />
+    </div>
+  </div>
+</section>
+  {% endblock %}

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -27,10 +27,10 @@
     <div class="col-12">
       <h2>Ubuntu 为您提供哪些服务</h2>
       <ul class="p-list">
-        <li class="p-list is-ticked">方便您有效构建 OpenStack 云所需的一切服务</li>
-        <li class="p-list is-ticked">在领先的公共云上使用经认证的Ubuntu 服务器映像</li>
-        <li class="p-list is-ticked">成熟的工具帮您大规模配置、构建、管理和支持您的云</li>
-        <li class="p-list is-ticked">定制化咨询业务和后继 Ubuntu Advantage 支持订购服务等商业服务</li>
+        <li class="p-list__item is-ticked">方便您有效构建 OpenStack 云所需的一切服务</li>
+        <li class="p-list__item is-ticked">在领先的公共云上使用经认证的Ubuntu 服务器映像</li>
+        <li class="p-list__item is-ticked">成熟的工具帮您大规模配置、构建、管理和支持您的云</li>
+        <li class="p-list__item is-ticked">定制化咨询业务和后继 Ubuntu Advantage 支持订购服务等商业服务</li>
       </ul>
     </div>
   </div>

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -134,7 +134,6 @@
     <div class="col-6">
       <h2>需要服务或支持？</h2>
       <p>Canonical 是 Ubuntu 的技术支持公司，其直接参与开发 Ubuntu 和 OpenStack 的工程师会为用户提供现场咨询服务和培训服务。如果要在您的云启动和运行后获得后继支持服务，您可以订阅 Ubuntu Advantage 服务包（包括 Canonical 企业云管理软件 Landscape）。</p>
-      <p></p>
       <p><a href="http://www.ubuntu.com/management/ubuntu-advantage">请访问 www.ubuntu.com 进一步了解 Ubuntu Advantage</a></p>
     </div>
     <div class="col-6">


### PR DESCRIPTION
## Done
Convert cloud page to Vanilla

## QA
- Pull code
- Sanity check file deletions
- Run `./run serve --watch`
- View desktop page on http://0.0.0.0:8010/cloud

## Issue / Card
Fixes https://github.com/ubuntudesign/vanilla-squad/issues/65
