### PR TITLE
Update download links

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -28,10 +28,10 @@
       <div class="col-4 p-divider__block">
         <p>选择版本</p>
         <p>
-          <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.3-desktop-amd64.iso" class="p-button--brand" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.3 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+          <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-desktop-amd64.iso" class="p-button--brand" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.4 64 bit', 'From English-language Chinese download']);">64位下载键</a>
         </p>
         <p>
-          <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.3-desktop-i386.iso" class="p-button--brand" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.3 32 bit', 'From English-language Chinese download']);">32位下载键</a>
+          <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-desktop-i386.iso" class="p-button--brand" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04.4 32 bit', 'From English-language Chinese download']);">32位下载键</a>
         </p>
         <p>(如果你电脑的内存少于2GB,选择32位下载)</p>
       </div>


### PR DESCRIPTION
## Done

Update download links for 16.4 LTS

## QA

- Clone repo
- Checkout branch
- `./run serve`
- Go to [downloads page](http://0.0.0.0:8010/download/)
- Check that download links for 16.4 LTS download version 16.4.4

## Issue / Card

[Fixes #187](https://app.zenhub.com/workspace/o/canonical-websites/cn.ubuntu.com/issues/187)
