### PR TITLE
Only store what's needed in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+Dockerfile
+README.md
+manage.py
+node_modules/
+package.json
+run
+yarn-error.log
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ RUN pip3 install gunicorn
 
 # Set git commit ID
 ARG COMMIT_ID
-ENV COMMIT_ID=$COMMIT_ID
 RUN test -n "${COMMIT_ID}"
+RUN echo "${COMMIT_ID}" > version-info.txt
 
 # Import code, install code dependencies
 WORKDIR /srv
-ADD . .
-RUN pip3 install -r requirements.txt
+COPY . .
+RUN pip3 install -r requirements.txt && rm requirements.txt
 
 # Setup commands to run server
 ENTRYPOINT ["gunicorn", "webapp.wsgi", "-b"]


### PR DESCRIPTION
Be explicit rather than implicit about what's copied into the docker
image. Most of the files aren't needed afterall.