### PR TITLE
Update the iot store image

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -129,7 +129,7 @@
   <div class="row">
     <div class="u-equal-height">
       <div class="col-2 u-vertically-center">
-      <img src="http://cn.ubuntu.com/static/img/pictograms/picto-pack/picto-community-orange.svg" alt="">
+      <img src="/static/img/pictograms/picto-pack/picto-community-orange.svg" alt="">
     </div>
       <div class="col-7 prefix-1 suffix-1 u-vertically-center">
         <div>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -20,7 +20,7 @@
   </div>
   <div class="row">
     <div class="col-12 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/472914ed-Core-Snap-Store.jpg" alt="Snap store screenshot">
+      <img src="https://assets.ubuntu.com/v1/313be7a3-snapcraft.io_store.png" alt="Snap store screenshot">
     </div>
   </div>
 </div>
@@ -204,22 +204,22 @@
       <div class="col-7">
       <ul class="p-inline-images">
         <li class="p-inline-images__item">
-          <img src="http://cn.ubuntu.com/static/img/internet-of-things/logo-microsoft-azure.svg" alt="Microsoft Azure logo">
+          <img src="/static/img/internet-of-things/logo-microsoft-azure.svg" alt="Microsoft Azure logo">
         </li>
         <li class="p-inline-images__item">
-          <img src="http://cn.ubuntu.com/static/img/internet-of-things/logo-raspberry-pi-001.svg" alt="Raspberry Pie logo">
+          <img src="/static/img/internet-of-things/logo-raspberry-pi-001.svg" alt="Raspberry Pie logo">
         </li>
         <li class="p-inline-images__item">
-          <img src="http://cn.ubuntu.com/static/img/internet-of-things/logo-dell.svg" alt="Dell logo">
+          <img src="/static/img/internet-of-things/logo-dell.svg" alt="Dell logo">
         </li>
         <li class="p-inline-images__item">
-          <img src="http://cn.ubuntu.com/static/img/internet-of-things/logo-intel.svg" alt="Intel logo">
+          <img src="/static/img/internet-of-things/logo-intel.svg" alt="Intel logo">
         </li>
         <li class="p-inline-images__item">
-          <img src="http://cn.ubuntu.com/static/img/internet-of-things/logo-ros.svg" alt="ROS logo">
+          <img src="/static/img/internet-of-things/logo-ros.svg" alt="ROS logo">
         </li>
         <li class="p-inline-images__item">
-          <img src="http://cn.ubuntu.com/static/img/internet-of-things/logo-dji.svg" alt="DJI logo">
+          <img src="/static/img/internet-of-things/logo-dji.svg" alt="DJI logo">
         </li>
       </ul>
     </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -14,10 +14,10 @@
   <link rel="apple-touch-icon-precomposed" href="{{ STATIC_URL }}img/apple-touch-icon-precomposed.png">
   <link type="text/plain" rel="author" href="{% versioned_static 'files/humans.txt' %}" />
   <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/styles.css' %}" />
-  
+
 
   {% block head_extra %}{% endblock %}
-  <script src="http://tjs.sjs.sinajs.cn/open/api/js/wb.js" type="text/javascript" charset="utf-8"></script>
+  <script src="https://tjs.sjs.sinajs.cn/open/api/js/wb.js" type="text/javascript" charset="utf-8"></script>
 </head>
   <body>
   <!-- Google Tag Manager -->
@@ -46,7 +46,7 @@
   </div>
 
   <!-- footer content goes here -->
-  {% include "templates/footer.html" %} 
+  {% include "templates/footer.html" %}
 
 
   <script src="{% versioned_static 'global-nav/build/js/global.js' %}"></script>


### PR DESCRIPTION
## Done
Update the IoT image and removed some relative links to make the site secure again.

## QA
- Go to /iot
- See that the store image matches https://snapcraft.io/store

## Issue / Card
Fixes https://github.com/canonical-websites/cn.ubuntu.com/issues/211
