### PR TITLE
Add CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2
+
+defaults: &defaults
+  docker:
+    - image: canonicalwebteam/dev
+
+jobs:
+  python-tests:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip3 install -r requirements.txt
+      - run:
+          name: Run python tests
+          command: yarn test-py
+  python-lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Lint python code
+          command: yarn lint-py
+  scss-lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: yarn
+      - run:
+          name: Lint sass
+          command: yarn lint-scss
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - scss-lint
+      - python-lint
+      - python-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: required
-
-services:
-  - docker
-
-script:
-- ./run test

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "cn.ubuntu.com",
   "description": "Django website for cn.ubuntu.com",
   "scripts": {
-    "test": "sass-lint static/**/*.scss --verbose --no-exit",
+    "test": "yarn run lint-scss && yarn run lint-py && yarn run test-py",
+    "lint-py": "flake8 --exclude '*env*,node_modules'",
+    "lint-scss": "sass-lint static/**/*.scss --verbose --no-exit",
+    "test-py": "python3 manage.py test",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
     "serve": "./entrypoint 0.0.0.0:${PORT}",

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -1,5 +1,5 @@
 {% block footer %}
- 
+
 <footer class="p-footer u-no-margin--top">
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
## Done

Add CircleCI workflow to the project. Steps added are:
- Python tests.
- Python lint
- Sass lint

## QA
Check the CI wokrflow under my CircleCI space.

OR

- Fork cn.ubuntu.com.
- Add this feature branch to your fork.
- Enable project in your own CircleCI space.
- Follow the steps in https://circleci.com/docs/2.0/examples/#section=configuration to trigger a build.
- Check the workflow ran properly.

## Issue / Card
Fixes https://github.com/ubuntudesign/base-squad/issues/210