### PR TITLE
Updated snaps in desktop overview

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -119,11 +119,11 @@
         
           <div class="col-3">
             <div class="p-heading-icon">
-              <a class="p-heading-icon__header" href="https://snapcraft.io/corebird">
+              <a class="p-heading-icon__header" href="https://snapcraft.io/telegram-desktop">
                 
-                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/05/corebird.svg.png" alt="">
+                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon256.png" alt="">
                 
-                <h5 class="u-no-margin">Corebird</h5>
+                <h5 class="u-no-margin">Telegram Desktop</h5>
               </a>
             </div>
           </div>
@@ -143,11 +143,11 @@
         
           <div class="col-3">
             <div class="p-heading-icon">
-              <a class="p-heading-icon__header" href="https://snapcraft.io/gimp">
+              <a class="p-heading-icon__header" href="https://snapcraft.io/powershell">
                 
-                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/07/gimp.png" alt="">
+                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/09/Powershell_black.ico.png" alt="">
                 
-                <h5 class="u-no-margin">GIMP</h5>
+                <h5 class="u-no-margin">Powershell</h5>
               </a>
             </div>
           </div>
@@ -161,11 +161,11 @@
         
           <div class="col-3">
             <div class="p-heading-icon">
-              <a class="p-heading-icon__header" href="https://snapcraft.io/minecraft">
+              <a class="p-heading-icon__header" href="https://snapcraft.io/opera">
                 
-                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/12/minecraft_icon.png" alt="">
+                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/07/opera_DrRnkh0.png" alt="">
                 
-                <h5 class="u-no-margin">Minecraft</h5>
+                <h5 class="u-no-margin">Opera</h5>
               </a>
             </div>
           </div>
@@ -185,11 +185,11 @@
         
           <div class="col-3">
             <div class="p-heading-icon">
-              <a class="p-heading-icon__header" href="https://snapcraft.io/ora">
+              <a class="p-heading-icon__header" href="https://snapcraft.io/zenkit">
                 
-                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/01/256x256.png" alt="">
+                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/03/zenkit-small.png" alt="">
                 
-                <h5 class="u-no-margin">Ora</h5>
+                <h5 class="u-no-margin">Zenkit</h5>
               </a>
             </div>
           </div>
@@ -197,11 +197,11 @@
   
           <div class="col-3">
             <div class="p-heading-icon">
-              <a class="p-heading-icon__header" href="https://snapcraft.io/notepad-plus-plus">
+              <a class="p-heading-icon__header" href="https://snapcraft.io/bitwarden">
                 
-                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/02/notepad-plus-plus.png" alt="">
+                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/02/256x256.png" alt="">
                 
-                <h5 class="u-no-margin">Notepad-Plus-Plus</h5>
+                <h5 class="u-no-margin">Bitwarden</h5>
               </a>
             </div>
           </div>
@@ -250,11 +250,11 @@
     
           <div class="col-3">
             <div class="p-heading-icon">
-              <a class="p-heading-icon__header" href="https://snapcraft.io/nextcloud">
+              <a class="p-heading-icon__header" href="https://snapcraft.io/xonotic">
                 
-                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2016/06/icon.svg_1.png" alt="">
+                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/07/xonotic_256x.png" alt="">
                 
-                <h5 class="u-no-margin">Nextcloud</h5>
+                <h5 class="u-no-margin">Xonotic</h5>
               </a>
             </div>
           </div>
@@ -303,11 +303,11 @@
         
           <div class="col-3">
             <div class="p-heading-icon">
-              <a class="p-heading-icon__header" href="https://snapcraft.io/shattered-pixel-dungeon">
+              <a class="p-heading-icon__header" href="https://snapcraft.io/0ad">
                 
-                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/03/shattered-pixel-dungeon.png" alt="">
+                  <img class="p-heading-icon__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/12/icon256_f9302jP.png" alt="">
                 
-                <h5 class="u-no-margin">Shattered Pixel Dungeon</h5>
+                <h5 class="u-no-margin">0 A.D.</h5>
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Done

Updated the list of snaps on the desktop overview page to match top snaps, and removed deprecated snaps leading to 404's. 

## QA

- Check that the Snaps go to the right URL's

## Issue / Card

Fixes #236 

