### PR TITLE
Update to Vanilla v1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postcss": "^6.0.8",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.7.0"
+    "vanilla-framework": "1.8.0"
   },
   "dependencies": {
     "autoprefixer": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,9 +3064,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0.tgz#ae198e46f0823ee2d316bcd2783e4846df676728"
+vanilla-framework@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.0.tgz#b5aacc3ce60a521b8de8f160cb505807aadc7869"
 
 vendors@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
## Done
- Updated version of site to Vanilla 1.8

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8010/](http://0.0.0.0:8010/)
4. Compare with [live](https://cn.ubuntu.com/) and ensure that the site looks the same 