### PR TITLE
Fix legal footer link

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -13,7 +13,7 @@
             <a class="p-footer__link" href="/contact" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact Us', 'eventLabel' : 'cn.ubuntu.com - Footer link', 'eventValue' : undefined });">联系我们</a>
           </li>
           <li class="p-footer__item">
-            <a class="p-footer__link p-link--external" href="/legal">https://www.ubuntu.com/legal</a>
+            <a class="p-footer__link p-link--external" href="https://www.ubuntu.com/legal">Legal information</a>
           </li>
           <li class="p-footer__item">
             <a class="p-footer__link p-link--external" href="https://github.com/canonical-websites/cn.ubuntu.com/issues/new">Report a bug with this site</a>


### PR DESCRIPTION
Link in footer was leading to 404. Fix the link, and change link text to something friendlier (same as www.ubuntu.com).

QA
--

`./run`, go to footer, see the glorious link to "Legal information".