### PR TITLE
Fix bad merge

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -8,9 +8,6 @@
 @import 'patterns_navigation';
 @include cn-p-navigation;
 
-// Vendor
-@import '../global-nav/src/sass/main';
-
 // Import custom styles
 @import "custom/ubuntu_intro";
 @import "custom/heading-icon-small";


### PR DESCRIPTION
This was leading to this error:

    $ node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css'
    {
    "status": 1,
    "file": "/home/robin/git/cn.ubuntu.com/static/sass/styles.scss",
    "line": 12,
    "column": 1,
    "message": "File to import not found or unreadable: ../global-nav/src/sass/main.",
    "formatted": "Error: File to import not found or unreadable: ../global-nav/src/sass/main.\n        on line 12 of static/sass/styles.scss\n>> @import '../global-nav/src/sass/main';\n\n   ^\n"
    }

QA
--

Check `./run build` now passes, and `./run` runs the site.