### PR TITLE
Fix navigation with redirects

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,106 @@
+# [os] OS & editor files
+**/Desktop.ini
+**/Thumbs.db
+**/._*
+**/*.DS_Store
+**/*~
+**/\#*\#
+**/.AppleDouble
+**/.LSOverride
+**/.spelling
+**/.vscode
+**/*.swp
+**/.ropeproject
+.idea
+
+# Virtual environment
+env/
+env[23]/
+.env/
+.venv/
+venv/
+.Python
+.envrc
+
+# Data, compiled, build or log files
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+logs/
+lib64/
+parts/
+sdist/
+var/
+_site/
+**/*.*.map
+*.egg-info/
+.installed.cfg
+*.egg
+pip-log.txt
+pip-delete-this-directory.txt
+pids
+*.pid
+*.seed
+.*-metadata
+**/*.sqlite
+**/*.sqlite3
+**/*-cache/
+**/*.log
+**/*.bak
+**/*.manifest
+**/*.spec
+**/__pycache__/
+**/*.py[cod]
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Deliberately ignore certain project files
+# ==
+
+# Readmes
+README.md
+LICENSE
+LICENSE.md
+HACKING.md
+
+# The run script
+run
+.docker-project
+.*.hash
+
+# Node is only needed for building, not running
+package.json
+node_modules
+yarn.lock
+
+# Git, travis, docker
+.git
+.gitignore
+.travis.yml
+docker-compose.yml
+.docker
+Dockerfile
+
+# Sphinx documentation
+docs/_build/
+
+# Local dependencies
+.bundle/
+node_modules/
+vendor/
+bower_components/
+package-lock.json
+yarn.lock
+bin/

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,2 @@
+(?P<page>.*)/: "/{page}"
+(?P<page>.*).html: "/{page}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-canonicalwebteam.versioned-static==1.0.2
 Django==2.1.5
+canonicalwebteam.versioned-static==1.0.2
+canonicalwebteam.yaml-responses[django]==1.1.0
+canonicalwebteam.django_views==1.3.2
 whitenoise==3.3.1
 django-static-root-finder==0.3.1
-django-template-finder-view==0.3
 talisker==0.11.1
 gunicorn[gevent]

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -14,7 +14,6 @@ WHITENOISE_ALLOW_ALL_ORIGINS = False
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "false").lower() == "true"
 ALLOWED_HOSTS = ["*"]
-APPEND_SLASH = True
 
 # Application definition
 INSTALLED_APPS = ["whitenoise.runserver_nostatic", "canonicalwebteam"]

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,5 +1,11 @@
 from django.conf.urls import url
+from canonicalwebteam.django_views import TemplateFinder
+from canonicalwebteam.yaml_responses.django_helpers import (
+    create_redirect_views,
+)
 
-from .views import CmsTemplateFinder
-
-urlpatterns = [url(r"^(?P<template>.*/)?$", CmsTemplateFinder.as_view())]
+urlpatterns = create_redirect_views()
+urlpatterns += [
+    url(r"^(?P<template>.*)[^\/]$", TemplateFinder.as_view()),
+    url(r"^$", TemplateFinder.as_view()),
+]


### PR DESCRIPTION
The main thing here is that redirects work. Most importantly, redirects to remove slashes. Also, ignore node_modules from docker image.

QA
--

`./run`

Now make sure the site works, browse around. Also check:

``` bash
$ curl -I http://localhost:8010/internet-of-things/
HTTP/1.1 302 Found
Location: /internet-of-things

$ curl -I http://localhost:8010/internet-of-things
HTTP/1.1 200 OK
```