### PR TITLE
Add "test-site" CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,23 @@ defaults: &defaults
     - image: canonicalwebteam/dev
 
 jobs:
+  test-site:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: yarn && pip3 install -r requirements.txt
+      - run:
+          name: Build the site resources
+          command: yarn run build
+      - run:
+          name: Run the site server
+          command: ./entrypoint 0.0.0.0:80
+          background: true
+      - run:
+          name: Check site is accessible
+          command: sleep 1 && curl --head --fail --retry-delay 5 --retry 10  --retry-connrefused http://localhost
   python-tests:
     <<: *defaults
     steps:
@@ -37,6 +54,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - test-site
       - scss-lint
       - python-lint
       - python-tests


### PR DESCRIPTION
To check the site builds and runs fine, returning a <400 status.

Similar to developer.ubuntu.com and blog.ubuntu.com.

QA
--

See the "test-site" test pass.