### PR TITLE
Sets the active navigation link color to orange

### DIFF
--- a/static/sass/_settings_colors.scss
+++ b/static/sass/_settings_colors.scss
@@ -1,3 +1,4 @@
 $color-brand: #e95420;
 $color-accent: $color-brand;
 $color-navigation-background: #333;
+$color-navigation-active-bar: #e95420;


### PR DESCRIPTION
## Done
- Change the active navigation link color setting

## QA
- check out the demo service link
- make sure that the route you are at is highlighted in the nav with an orange underlin