### PR TITLE
Checks for blog as path root in blog item

### DIFF
--- a/templates/templates/header.html
+++ b/templates/templates/header.html
@@ -33,7 +33,7 @@
           <li class="p-navigation__link{% if request.path == url %} is-selected{% endif %}" role="menuitem"><a href="{{ url }}">容器</a></li>
           {% endwith %}
           {% with '/blog' as url %}
-          <li class="p-navigation__link{% if request.path == url %} is-selected{% endif %}" role="menuitem"><a href="{{ url }}">新闻中心</a></li>
+          <li class="p-navigation__link{% if request.path|slice:":5" == url %} is-selected{% endif %}" role="menuitem"><a href="{{ url }}">新闻中心</a></li>
           {% endwith %}
         </ul>
       </nav>


### PR DESCRIPTION
## Done
- Checks if the beginning of a path contains `/blog` and highlights that blog item accordignly

## QA

-  on the demo service, navigate to a blog article and verify that the navigation item is still highlighted