### PR TITLE
Correctly access the display category for the footer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2
-canonicalwebteam.blog==1.2.0
+canonicalwebteam.blog==1.3.2
 canonicalwebteam.http==1.0.1
 canonicalwebteam.versioned-static==1.0.2
 canonicalwebteam.yaml-responses[django]==1.1.0

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -48,7 +48,7 @@
   </div>
   <p class="blog-p-card__footer">
   {% if article.display_category %}
-     {{ display_category.name }}
+     {{ article.display_category.name }}
   {% endif %}
   </p>
 </div>


### PR DESCRIPTION
## Done

- Correctly access the article object in template to display the category in the footer

## QA
- ./run
- go to `localhost:8010/blog` and make sure that some articles correctly display a category name in the footer